### PR TITLE
Fix Tkinter error message on close bug 

### DIFF
--- a/autogaita/autogaita.py
+++ b/autogaita/autogaita.py
@@ -110,10 +110,6 @@ def gui():
     for r in range(1, num_rows):
         root.grid_rowconfigure(r, weight=1)
 
-    # ................................  close button   ................................
-    # "quit" ensures that also the ghost_root is destroyed when the window is closed
-    root.protocol("WM_DELETE_WINDOW", root.quit)
-
     # ...................................  mainloop  ...................................
     root.mainloop()
 

--- a/autogaita/autogaita.py
+++ b/autogaita/autogaita.py
@@ -110,6 +110,10 @@ def gui():
     for r in range(1, num_rows):
         root.grid_rowconfigure(r, weight=1)
 
+    # ................................  close button   ................................
+    # "quit" ensures that also the ghost_root is destroyed when the window is closed
+    root.protocol("WM_DELETE_WINDOW", root.quit)
+
     # ...................................  mainloop  ...................................
     root.mainloop()
 

--- a/autogaita/autogaita_dlc_gui.py
+++ b/autogaita/autogaita_dlc_gui.py
@@ -243,7 +243,8 @@ def dlc_gui():
             # results variable is only defined later in populate_run_window()
             # therefore only cfg settings will be updated
             update_config_file("results dict not defined yet", cfg),
-            root.after(1, root.destroy()),
+            root.withdraw(),
+            root.after(5000, root.destroy),
         ),
     )
     close_button.grid(row=10, column=0, pady=(10, 15), padx=30, sticky="nsew")

--- a/autogaita/autogaita_simi_gui.py
+++ b/autogaita/autogaita_simi_gui.py
@@ -388,7 +388,8 @@ def simi_gui():
         hover_color=HOVER_COLOR,
         command=lambda: (
             update_config_file(results, cfg),
-            root.after(1, root.destroy()),
+            root.withdraw(),
+            root.after(5000, root.destroy),
         ),
     )
     close_button.grid(row=19, column=1, sticky="nsew", padx=10, pady=(10, 5))


### PR DESCRIPTION
After closing the AutoGaitA DLC or Simi window trough the integrated close button the following error message was displayed: 

> invalid command name "4437278848update"
> 
> while executing
> 
> "4437278848update"
> 
> ("after" script)

This error is related to the _after()_ function and is displayed when Tkinter tries to perform an operation while the root instance is already destroyed. 

To fix this issue I first only minimise the window (with _withdraw()_) and then wait 5 seconds before eventually destroying it (_after(5000, destroy)_).


