### PR TITLE
Plot Panel Feature to preview plots in the AutoGaitA GUI using tkinter 

### DIFF
--- a/autogaita/autogaita_dlc.py
+++ b/autogaita/autogaita_dlc.py
@@ -15,6 +15,10 @@ import customtkinter as ctk
 import seaborn as sns
 
 # %% constants
+matplotlib.use("agg")
+# Agg is a non-interactive backend for plotting that can only write to files
+# this is used to generate and save the plot figures
+# later a tkinter backend (FigureCanvasTkAgg) is used for the plot panel
 plt.rcParams["figure.dpi"] = 300  # increase resolution of figures
 DIRECTION_DLC_THRESHOLD = 0.95  # DLC confidence used for direction-detection
 TIME_COL = "Time"
@@ -58,8 +62,15 @@ def dlc(info, folderinfo, cfg):
     5) plots
     """
     # .............. initiate plot panel class and build loading screen ................
+    # create class instance independently of "dont_show_plots" to not break the code
     plot_panel_instance = PlotPanel()
-    plot_panel_instance.build_plot_panel_loading_screen()
+
+    if cfg["dont_show_plots"] is True:
+        pass  # going on without building the loading screen
+
+    elif cfg["dont_show_plots"] is False:  # -> show plot panel
+        # build loading screen
+        plot_panel_instance.build_plot_panel_loading_screen()
 
     # ................................  preparation  ...................................
     data = some_prep(info, folderinfo, cfg)
@@ -486,14 +497,6 @@ def check_and_expand_cfg(data, cfg, info):
             write_issues_to_textfile(beam_col_error_message, info)
             print(beam_col_error_message)
             return
-
-    # dont show plots
-    # !!! If users should complain that they dont get figures but they should, it might
-    #     be because these lines wrongly determine user to be in non-interactive mode
-    #     while they are not!
-    if not hasattr(sys, "ps1") and not sys.flags.interactive:
-        cfg["dont_show_plots"] = True
-        matplotlib.use("agg")
 
     # never normalise @ SC level if user subtracted a beam
     if cfg["subtract_beam"]:
@@ -1475,9 +1478,14 @@ def plot_results(info, results, folderinfo, cfg, plot_panel_instance):
                 average_data, std_data, info, cfg, plot_panel_instance
             )
 
-    # Destroy loading screen and build plot panel with all figures
-    plot_panel_instance.destroy_plot_panel_loading_screen()
-    plot_panel_instance.build_plot_panel()
+    # ........................optional - 11 - build plot panel..........................
+    print("paramter", cfg["dont_show_plots"])
+    if cfg["dont_show_plots"] is True:
+        pass  # going on without building the plot window
+    elif cfg["dont_show_plots"] is False:  # -> show plot panel
+        # Destroy loading screen and build plot panel with all figures
+        plot_panel_instance.destroy_plot_panel_loading_screen()
+        plot_panel_instance.build_plot_panel()
 
 
 # ..................................  inner functions  .................................
@@ -1579,7 +1587,9 @@ def plot_joint_y_by_x(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
         if dont_show_plots:
             plt.close(f[j])
 
-        plot_panel_instance.figures.append(f[j])
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f[j])
 
 
 def plot_angles_by_time(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
@@ -1632,7 +1642,9 @@ def plot_angles_by_time(all_steps_data, sc_idxs, info, cfg, plot_panel_instance)
         if dont_show_plots:
             plt.close(f[a])
 
-        plot_panel_instance.figures.append(f[a])
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f[a])
 
 
 def plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
@@ -1691,7 +1703,9 @@ def plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_in
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_forelimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
@@ -1749,7 +1763,9 @@ def plot_forelimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_in
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_joint_y_by_average_SC(average_data, std_data, info, cfg, plot_panel_instance):
@@ -1797,7 +1813,9 @@ def plot_joint_y_by_average_SC(average_data, std_data, info, cfg, plot_panel_ins
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_angles_by_average_SC(average_data, std_data, info, cfg, plot_panel_instance):
@@ -1842,7 +1860,9 @@ def plot_angles_by_average_SC(average_data, std_data, info, cfg, plot_panel_inst
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_x_velocities_by_average_SC(
@@ -1898,7 +1918,9 @@ def plot_x_velocities_by_average_SC(
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_angular_velocities_by_average_SC(
@@ -1946,7 +1968,9 @@ def plot_angular_velocities_by_average_SC(
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_x_acceleration_by_average_SC(
@@ -2002,7 +2026,9 @@ def plot_x_acceleration_by_average_SC(
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def plot_angular_acceleration_by_average_SC(
@@ -2054,7 +2080,9 @@ def plot_angular_acceleration_by_average_SC(
     if dont_show_plots:
         plt.close(f)
 
-    plot_panel_instance.figures.append(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def save_figures(figure, results_dir, name, figure_file_string):
@@ -2170,13 +2198,15 @@ class PlotPanel:
         for fig in self.figures:
             # dpi adjusted to increase visibilty/readability
             fig.set_dpi(100)
-            # right margin adjusted to display the legend properly
-            fig.subplots_adjust(right=0.88)
+            # to adjust margins within the figure
+            # in case there are a lot of steps in one run (-> the legend is super long)
+            # the figure won't be displayed properly.
+            fig.set_constrained_layout(True)
 
         # Initialize the plot panel with the first figure
         self.plot_panel = FigureCanvasTkAgg(
             self.figures[self.current_fig_index], master=self.plotwindow
-        )
+        )  # index used for buttons
         self.plot_panel.get_tk_widget().grid(
             row=0, column=0, padx=10, pady=10, sticky="nsew"
         )
@@ -2243,12 +2273,6 @@ class PlotPanel:
 
 def print_finish(info, cfg):
     """Print that we finished this program"""
-    # unpack
-    dont_show_plots = cfg["dont_show_plots"]
-
-    if dont_show_plots:
-        plt.pause(1)  # so we ensure that plots are plotted to python before print
-
     print("\n***************************************************")
     print("* GAITA FINISHED - RESULTS WERE SAVED HERE:       *")
     print("* " + info["results_dir"] + " *")

--- a/autogaita/autogaita_dlc.py
+++ b/autogaita/autogaita_dlc.py
@@ -9,6 +9,9 @@ import numpy as np
 import math
 import matplotlib
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+import tkinter as tk
+import customtkinter as ctk
 import seaborn as sns
 
 # %% constants
@@ -54,6 +57,9 @@ def dlc(info, folderinfo, cfg):
     4) step cycle normalisation, dataframe creation & XLS-exportation
     5) plots
     """
+    # .............. initiate plot panel class and build loading screen ................
+    plot_panel_instance = PlotPanel()
+    plot_panel_instance.build_plot_panel_loading_screen()
 
     # ................................  preparation  ...................................
     data = some_prep(info, folderinfo, cfg)
@@ -70,7 +76,7 @@ def dlc(info, folderinfo, cfg):
     results = analyse_and_export_stepcycles(data, all_cycles, info, folderinfo, cfg)
 
     # ................................  plots  .........................................
-    plot_results(info, results, folderinfo, cfg)
+    plot_results(info, results, folderinfo, cfg, plot_panel_instance)
 
     # ............................  print finish  ......................................
     print_finish(info, cfg)
@@ -1402,7 +1408,7 @@ def add_step_separators(dataframe, nanvector, numvector):
 #    would be coded as commented out in plot_joint_y_by_x
 
 
-def plot_results(info, results, folderinfo, cfg):
+def plot_results(info, results, folderinfo, cfg, plot_panel_instance):
     """Plot results - y coords by x coords & average angles over SC %"""
     # unpack
     fore_joints = cfg["fore_joints"]
@@ -1421,41 +1427,57 @@ def plot_results(info, results, folderinfo, cfg):
     cfg["sc_num"] = len(sc_idxs)  # add number of scs for plotting SE if wanted
 
     # .........................1 - y coords by x coords.................................
-    plot_joint_y_by_x(all_steps_data, sc_idxs, info, cfg)
+    plot_joint_y_by_x(all_steps_data, sc_idxs, info, cfg, plot_panel_instance)
 
     # ...............................2 - angles by time.................................
     if angles["name"]:
-        plot_angles_by_time(all_steps_data, sc_idxs, info, cfg)
+        plot_angles_by_time(all_steps_data, sc_idxs, info, cfg, plot_panel_instance)
 
     # ..........................3 - hindlimb stick diagram..............................
-    plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg)
+    plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_instance)
 
     # ...........................4 - forelimb stick diagram.............................
     if fore_joints:
-        plot_forelimb_stickdiagram(all_steps_data, sc_idxs, info, cfg)
+        plot_forelimb_stickdiagram(
+            all_steps_data, sc_idxs, info, cfg, plot_panel_instance
+        )
 
     # .....................5 - average joints' y over SC percentage.....................
-    plot_joint_y_by_average_SC(average_data, std_data, info, cfg)
+    plot_joint_y_by_average_SC(average_data, std_data, info, cfg, plot_panel_instance)
 
     # ........................6 - average angles over SC percentage.....................
     if angles["name"]:
-        plot_angles_by_average_SC(average_data, std_data, info, cfg)
+        plot_angles_by_average_SC(
+            average_data, std_data, info, cfg, plot_panel_instance
+        )
 
     # .................7 - average x velocities over SC percentage......................
-    plot_x_velocities_by_average_SC(average_data, std_data, info, cfg)
+    plot_x_velocities_by_average_SC(
+        average_data, std_data, info, cfg, plot_panel_instance
+    )
 
     # ..............8 - average angular velocities over SC percentage...................
     if angles["name"]:
-        plot_angular_velocities_by_average_SC(average_data, std_data, info, cfg)
+        plot_angular_velocities_by_average_SC(
+            average_data, std_data, info, cfg, plot_panel_instance
+        )
 
     # ............optional - 9 - average x acceleration over SC percentage..............
     if x_acceleration:
-        plot_x_acceleration_by_average_SC(average_data, std_data, info, cfg)
+        plot_x_acceleration_by_average_SC(
+            average_data, std_data, info, cfg, plot_panel_instance
+        )
 
     # .........optional - 10 - average angular acceleration over SC percentage..........
     if angles["name"]:
         if angular_acceleration:
-            plot_angular_acceleration_by_average_SC(average_data, std_data, info, cfg)
+            plot_angular_acceleration_by_average_SC(
+                average_data, std_data, info, cfg, plot_panel_instance
+            )
+
+    # Destroy loading screen and build plot panel with all figures
+    plot_panel_instance.destroy_plot_panel_loading_screen()
+    plot_panel_instance.build_plot_panel()
 
 
 # ..................................  inner functions  .................................
@@ -1501,7 +1523,7 @@ def extract_sc_idxs(all_steps_data):
     return sc_idxs
 
 
-def plot_joint_y_by_x(all_steps_data, sc_idxs, info, cfg):
+def plot_joint_y_by_x(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
     """1 - Plot joints' y coordinates as a function of their x for each SC"""
 
     # unpack
@@ -1557,8 +1579,10 @@ def plot_joint_y_by_x(all_steps_data, sc_idxs, info, cfg):
         if dont_show_plots:
             plt.close(f[j])
 
+        plot_panel_instance.figures.append(f[j])
 
-def plot_angles_by_time(all_steps_data, sc_idxs, info, cfg):
+
+def plot_angles_by_time(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
     """2 - Plot joints' angles as a function of time for each SC"""
 
     # unpack
@@ -1608,8 +1632,10 @@ def plot_angles_by_time(all_steps_data, sc_idxs, info, cfg):
         if dont_show_plots:
             plt.close(f[a])
 
+        plot_panel_instance.figures.append(f[a])
 
-def plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg):
+
+def plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
     """3 - Plot a stick diagram of the hindlimb"""
 
     # unpack
@@ -1665,8 +1691,10 @@ def plot_hindlimb_stickdiagram(all_steps_data, sc_idxs, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_forelimb_stickdiagram(all_steps_data, sc_idxs, info, cfg):
+
+def plot_forelimb_stickdiagram(all_steps_data, sc_idxs, info, cfg, plot_panel_instance):
     """4 - Plot a stick diagram of the forelimb (for hindlimb stepcycles)"""
 
     # unpack
@@ -1721,8 +1749,10 @@ def plot_forelimb_stickdiagram(all_steps_data, sc_idxs, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_joint_y_by_average_SC(average_data, std_data, info, cfg):
+
+def plot_joint_y_by_average_SC(average_data, std_data, info, cfg, plot_panel_instance):
     """5 - Plot joints' y as a function of average SC's percentage"""
 
     # unpack
@@ -1767,8 +1797,10 @@ def plot_joint_y_by_average_SC(average_data, std_data, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_angles_by_average_SC(average_data, std_data, info, cfg):
+
+def plot_angles_by_average_SC(average_data, std_data, info, cfg, plot_panel_instance):
     """6 - Plot Angles as a function of average SC's percentage"""
 
     # unpack
@@ -1810,8 +1842,12 @@ def plot_angles_by_average_SC(average_data, std_data, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_x_velocities_by_average_SC(average_data, std_data, info, cfg):
+
+def plot_x_velocities_by_average_SC(
+    average_data, std_data, info, cfg, plot_panel_instance
+):
     """7 - Plot x velocities as a function of average SC's percentage"""
 
     # unpack
@@ -1862,8 +1898,12 @@ def plot_x_velocities_by_average_SC(average_data, std_data, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_angular_velocities_by_average_SC(average_data, std_data, info, cfg):
+
+def plot_angular_velocities_by_average_SC(
+    average_data, std_data, info, cfg, plot_panel_instance
+):
     """8 - Plot angular velocities as a function of average SC's percentage"""
 
     # unpack
@@ -1906,8 +1946,12 @@ def plot_angular_velocities_by_average_SC(average_data, std_data, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_x_acceleration_by_average_SC(average_data, std_data, info, cfg):
+
+def plot_x_acceleration_by_average_SC(
+    average_data, std_data, info, cfg, plot_panel_instance
+):
     """9 - (optional) Plot x acceleration as a function of average SC's percentage"""
 
     # unpack
@@ -1958,8 +2002,12 @@ def plot_x_acceleration_by_average_SC(average_data, std_data, info, cfg):
     if dont_show_plots:
         plt.close(f)
 
+    plot_panel_instance.figures.append(f)
 
-def plot_angular_acceleration_by_average_SC(average_data, std_data, info, cfg):
+
+def plot_angular_acceleration_by_average_SC(
+    average_data, std_data, info, cfg, plot_panel_instance
+):
     """10 - (optional) Plot angular acceleration as a function of average SC's
     percentage
     """
@@ -2005,6 +2053,8 @@ def plot_angular_acceleration_by_average_SC(average_data, std_data, info, cfg):
     save_figures(f, results_dir, name, figure_file_string)
     if dont_show_plots:
         plt.close(f)
+
+    plot_panel_instance.figures.append(f)
 
 
 def save_figures(figure, results_dir, name, figure_file_string):
@@ -2063,6 +2113,129 @@ def generate_sc_latency_label(all_steps_data, this_sc_idx, sampling_rate, time_c
         + "s"
     )
     return this_label
+
+
+class PlotPanel:
+    def __init__(self):
+        self.figures = []
+        self.current_fig_index = 0
+
+    # .........................  loading screen  ................................
+    def build_plot_panel_loading_screen(self):
+        """Builds a loading screen that is shown while plots are generated"""
+        # Build window
+        self.loading_screen = ctk.CTkToplevel()
+        self.loading_screen.title("Loading...")
+        self.loading_screen.geometry("300x300")
+        self.loading_label_strings = [
+            "Plots are generated, please wait.",
+            "Plots are generated, please wait..",
+            "Plots are generated, please wait...",
+        ]
+        self.loading_label = ctk.CTkLabel(
+            self.loading_screen, text=self.loading_label_strings[0]
+        )
+        self.loading_label.pack(pady=130, padx=40, anchor="w")
+
+        # Animate the text
+        self.animate(counter=1)
+
+    # Cycle through loading labels to animate the loading screen
+    def animate(self, counter):
+        self.loading_label.configure(text=self.loading_label_strings[counter])
+        self.loading_screen.after(
+            500, self.animate, (counter + 1) % len(self.loading_label_strings)
+        )
+
+    def destroy_plot_panel_loading_screen(self):
+        self.loading_screen.destroy()
+
+    # .........................  plot panel   ................................
+    def build_plot_panel(self):
+        """Creates the window/"panel" in which the plots are shown"""
+        # Set up of the plotpanel
+        ctk.set_appearance_mode("dark")  # Modes: system (default), light, dark
+        ctk.set_default_color_theme("green")  # Themes: blue , dark-blue, green
+        self.plotwindow = ctk.CTkToplevel()
+        self.plotwindow.title("AutoGaitA Plot Panel")
+
+        # Set size to 50% of screen
+        screen_width = self.plotwindow.winfo_screenwidth()
+        window_width = int(screen_width * 0.5)
+        # 0.75 to gain a ration of 1.333 (that of matplotlib figures) and 1.05 for toolbar + buttons
+        window_height = window_width * 0.75 * 1.05
+        self.plotwindow.geometry(f"{window_width}x{window_height}")
+
+        # Adjust figures for the plot panel
+        for fig in self.figures:
+            # dpi adjusted to increase visibilty/readability
+            fig.set_dpi(100)
+            # right margin adjusted to display the legend properly
+            fig.subplots_adjust(right=0.88)
+
+        # Initialize the plot panel with the first figure
+        self.plot_panel = FigureCanvasTkAgg(
+            self.figures[self.current_fig_index], master=self.plotwindow
+        )
+        self.plot_panel.get_tk_widget().grid(
+            row=0, column=0, padx=10, pady=10, sticky="nsew"
+        )
+
+        # Create toolbar frame and place it in the middle row
+        self.toolbar_frame = tk.Frame(self.plotwindow)
+        self.toolbar_frame.grid(row=1, column=0, sticky="ew")
+
+        self.toolbar = NavigationToolbar2Tk(self.plot_panel, self.toolbar_frame)
+        self.toolbar.update()
+
+        # Create navigation buttons frame
+        self.button_frame = tk.Frame(self.plotwindow)
+        self.button_frame.grid(row=2, column=0, sticky="ew")
+
+        self.prev_button = ctk.CTkButton(
+            self.button_frame, text="<< Previous", command=self.show_previous
+        )
+        self.next_button = ctk.CTkButton(
+            self.button_frame, text="Next >>", command=self.show_next
+        )
+        self.prev_button.grid(row=0, column=0, sticky="ew")
+        self.next_button.grid(row=0, column=1, sticky="ew")
+
+        self.button_frame.grid_columnconfigure(0, weight=1)
+        self.button_frame.grid_columnconfigure(1, weight=1)
+
+        # Configure grid layout
+        self.plotwindow.grid_rowconfigure(0, weight=1)
+        self.plotwindow.grid_rowconfigure(1, weight=0)
+        self.plotwindow.grid_rowconfigure(2, weight=0)
+        self.plotwindow.grid_columnconfigure(0, weight=1)
+
+    def show_previous(self):
+        if self.current_fig_index > 0:
+            self.current_fig_index -= 1
+            self.update_plot_and_toolbar()
+
+    def show_next(self):
+        if self.current_fig_index < len(self.figures) - 1:
+            self.current_fig_index += 1
+            self.update_plot_and_toolbar()
+
+    def update_plot_and_toolbar(self):
+        # Clear the current plot panel
+        self.plot_panel.get_tk_widget().grid_forget()
+
+        # Update the plot panel with the new figure
+        self.plot_panel = FigureCanvasTkAgg(
+            self.figures[self.current_fig_index], master=self.plotwindow
+        )
+        self.plot_panel.get_tk_widget().grid(row=0, column=0, sticky="nsew")
+        self.plot_panel.draw()
+
+        # Destroy toolbar and create a new one
+        # (This has to be done, otherwise the toolbar won't function for a new plot)
+        self.toolbar.destroy()
+        self.toolbar = NavigationToolbar2Tk(self.plot_panel, self.toolbar_frame)
+        self.toolbar.update()
 
 
 # %% local functions 5 - print finish

--- a/autogaita/autogaita_dlc.py
+++ b/autogaita/autogaita_dlc.py
@@ -1479,7 +1479,6 @@ def plot_results(info, results, folderinfo, cfg, plot_panel_instance):
             )
 
     # ........................optional - 11 - build plot panel..........................
-    print("paramter", cfg["dont_show_plots"])
     if cfg["dont_show_plots"] is True:
         pass  # going on without building the plot window
     elif cfg["dont_show_plots"] is False:  # -> show plot panel
@@ -2185,7 +2184,9 @@ class PlotPanel:
         ctk.set_appearance_mode("dark")  # Modes: system (default), light, dark
         ctk.set_default_color_theme("green")  # Themes: blue , dark-blue, green
         self.plotwindow = ctk.CTkToplevel()
-        self.plotwindow.title("AutoGaitA Plot Panel")
+        self.plotwindow.title(
+            f"AutoGaitA Plot Panel {self.current_fig_index+1}/{len(self.figures)}"
+        )
 
         # Set size to 50% of screen
         screen_width = self.plotwindow.winfo_screenwidth()
@@ -2266,6 +2267,11 @@ class PlotPanel:
         self.toolbar.destroy()
         self.toolbar = NavigationToolbar2Tk(self.plot_panel, self.toolbar_frame)
         self.toolbar.update()
+
+        # Update title
+        self.plotwindow.title(
+            f"AutoGaitA Plot Panel {self.current_fig_index+1}/{len(self.figures)}"
+        )
 
 
 # %% local functions 5 - print finish

--- a/autogaita/autogaita_dlc_gui.py
+++ b/autogaita/autogaita_dlc_gui.py
@@ -237,7 +237,7 @@ def dlc_gui():
     )
     subtract_beam_checkbox.grid(row=6, column=0)
     # plot plots to python
-    showplots_string = "Don't show plots in Python (save only)"
+    showplots_string = "Don't show plots in GUI (save only)"
     showplots_checkbox = ctk.CTkCheckBox(
         root,
         text=showplots_string,

--- a/autogaita/autogaita_group.py
+++ b/autogaita/autogaita_group.py
@@ -13,6 +13,9 @@ import matplotlib
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib.animation import FuncAnimation, FFMpegWriter
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+import tkinter as tk
+import customtkinter as ctk
 from pingouin import sphericity, mixed_anova
 from scipy import stats
 import seaborn as sns
@@ -30,7 +33,12 @@ import seaborn as sns
 
 
 # %% constants
-
+# SET PLT BACKEND
+matplotlib.use("agg")
+# Agg is a non-interactive backend for plotting that can only write to files
+# this is used to generate and save the plot figures
+# later a tkinter backend (FigureCanvasTkAgg) is used for the plot panel
+# increase resolution of figures
 # INCREASE RESOLUTION OF FIGURES
 plt.rcParams["figure.dpi"] = 300
 
@@ -93,8 +101,18 @@ def group(folderinfo, cfg):
     7) perform the RM-/Mixed-ANOVA
     8) plots
     """
+    # .............. initiate plot panel class and build loading screen ................
+    # create class instance independently of "dont_show_plots" to not break the code
+    plot_panel_instance = PlotPanel()
 
-    # ..............................  print finish  ....................................
+    if cfg["dont_show_plots"] is True:
+        pass  # going on without building the loading screen
+
+    elif cfg["dont_show_plots"] is False:  # -> show plot panel
+        # build loading screen
+        plot_panel_instance.build_plot_panel_loading_screen()
+
+    # ..............................  print start  ....................................
     print_start(folderinfo, cfg)
 
     # ..................................  unpack  ......................................
@@ -111,7 +129,7 @@ def group(folderinfo, cfg):
 
     # ...................................  PCA  ........................................
     if cfg["PCA_variables"]:  # empty lists are falsey!
-        PCA_on_a_limb(avg_dfs, folderinfo, cfg)
+        PCA_on_a_limb(avg_dfs, folderinfo, cfg, plot_panel_instance)
 
     # ..............................  prepare statistics  ..............................
     stats_df = create_stats_df(avg_dfs, folderinfo, cfg)
@@ -121,7 +139,13 @@ def group(folderinfo, cfg):
         if cfg["do_permtest"]:
             for stats_var in cfg["stats_variables"]:
                 cluster_extent_test(
-                    stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, cfg
+                    stats_df,
+                    g_avg_dfs,
+                    g_std_dfs,
+                    stats_var,
+                    folderinfo,
+                    cfg,
+                    plot_panel_instance,
                 )
 
         # ..................................  ANOVA  ...................................
@@ -132,7 +156,7 @@ def group(folderinfo, cfg):
                 )
 
     # ..................................  plots  .......................................
-    plot_results(g_avg_dfs, g_std_dfs, folderinfo, cfg)
+    plot_results(g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance)
 
     # ..............................  print finish  ....................................
     print_finish(folderinfo)
@@ -312,26 +336,6 @@ def extract_cfg_vars(folderinfo, cfg):
                 + "just don't choose any variables for it."
             )
             cfg["number_of_PCs"] = 2  # make sure to update in cfg dict
-
-    # ..............................  dont show plots  .................................
-    # => in group gaita is always dependent on user system
-    # !!! THIS DOES NOT PLOT ANYTHING BUT I HAD TO DO IT LIKE THIS OTHERWISE IT CRASHES
-    # !!! If users should complain that they dont get figures but they should, it might
-    #     be because these lines wrongly determine user to be in non-interactive mode
-    #     while they are not!
-    # if not hasattr(sys, "ps1") and not sys.flags.interactive:
-    #     cfg["dont_show_plots"] = True
-    #     matplotlib.use("agg")
-    # else:
-    #     cfg["dont_show_plots"] = False
-    # !!! UPDATE FOR PYTHON MODULE
-    # ==> I just always set this to True to not show plots because otherwise weird
-    #     things happened with grouprun_ functions
-    # ==> .agg is used because otherwise we get a warning for f,ax=plt.subplots()
-    # ==> Not sure why this is different for our first-level GUIs but I'll just try
-    #     to implement a window for showing plots using GUI
-    matplotlib.use("agg")
-    cfg["dont_show_plots"] = True
 
     return cfg
 
@@ -895,7 +899,7 @@ def grand_avg_and_std(avg_dfs, folderinfo, cfg):
 # %% ...........................  local functions #4 - PCA  ............................
 
 
-def PCA_on_a_limb(avg_dfs, folderinfo, cfg):
+def PCA_on_a_limb(avg_dfs, folderinfo, cfg, plot_panel_instance):
     """PCA on joint y values of a limb (mouse: hindlimb, humans: leg of interest)"""
 
     # print info
@@ -907,7 +911,7 @@ def PCA_on_a_limb(avg_dfs, folderinfo, cfg):
     # save PCA info to xlsx file
     PCA_info_to_xlsx(PCA_df, PCA_info, folderinfo, cfg)
     # plot the scatterplot
-    plot_PCA(PCA_df, PCA_info, folderinfo, cfg)
+    plot_PCA(PCA_df, PCA_info, folderinfo, cfg, plot_panel_instance)
 
 
 def PCA_info_to_xlsx(PCA_df, PCA_info, folderinfo, cfg):
@@ -1004,7 +1008,7 @@ def run_PCA(PCA_df, features, cfg):
     return PCA_df, PCA_info
 
 
-def plot_PCA(PCA_df, PCA_info, folderinfo, cfg):
+def plot_PCA(PCA_df, PCA_info, folderinfo, cfg, plot_panel_instance):
     """Plot a scatterplot and colour based on group name"""
 
     # unpack
@@ -1070,18 +1074,17 @@ def plot_PCA(PCA_df, PCA_info, folderinfo, cfg):
             + "%"
         )
     save_figures(f, results_dir, "PCA Scatterplot")
-    if dont_show_plots:
-        plt.close(f)
-    else:
-        plt.show()
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
     # 3d scatterplot image file
     if number_of_PCs > 2:
         save_figures(f_3d, results_dir, "PCA 3D Scatterplot")
-        if dont_show_plots:
-            plt.close(f_3d)
-        else:
-            plt.show()
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
         # 3d scatterplot rotating video file
         if save_3D_PCA_video:
@@ -1135,7 +1138,9 @@ def create_stats_df(avg_dfs, folderinfo, cfg):
 
 
 # ...............................  main function  ......................................
-def cluster_extent_test(stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, cfg):
+def cluster_extent_test(
+    stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, cfg, plot_panel_instance
+):
     """Main function running a cluster-extent permutation test of N contrasts for a
     given dependent variable
     """
@@ -1183,7 +1188,13 @@ def cluster_extent_test(stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, c
     )
     # plot results
     plot_permutation_test_results(
-        g_avg_dfs, g_std_dfs, trueobs_results_df, stats_var, folderinfo, cfg
+        g_avg_dfs,
+        g_std_dfs,
+        trueobs_results_df,
+        stats_var,
+        folderinfo,
+        cfg,
+        plot_panel_instance,
     )
 
 
@@ -1346,7 +1357,13 @@ def test_trueobs_clusters(
 
 # ...................................  plot results  ...................................
 def plot_permutation_test_results(
-    g_avg_dfs, g_std_dfs, trueobs_results_df, stats_var, folderinfo, cfg
+    g_avg_dfs,
+    g_std_dfs,
+    trueobs_results_df,
+    stats_var,
+    folderinfo,
+    cfg,
+    plot_panel_instance,
 ):
     """Plot a Nx1 or N/2x2 figure of our contrasts' permutation test results."""
 
@@ -1469,10 +1486,11 @@ def plot_permutation_test_results(
     figure_file_string = stats_var + " - Cluster-extent Test"
     f.suptitle(figure_file_string, fontsize=PERM_PLOT_SUPLABEL_SIZE, y=0.993)
     save_figures(f, results_dir, figure_file_string)
-    if dont_show_plots:
-        plt.close(f)
-    else:
-        plt.show()
+
+    plt.close(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def extract_all_clusters(trueobs_results_df, contrast):
@@ -1499,7 +1517,9 @@ def extract_all_clusters(trueobs_results_df, contrast):
 # %% .................  local functions #7 - 2-way RM/Mixed-ANOVA  .....................
 
 
-def twoway_RMANOVA(stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, cfg):
+def twoway_RMANOVA(
+    stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, cfg, plot_panel_instance
+):
     """Perform a two-way RM-ANOVA with the factors group (between or within) & SC
     percentage (within) on a given dependent variable
     """
@@ -1526,7 +1546,13 @@ def twoway_RMANOVA(stats_df, g_avg_dfs, g_std_dfs, stats_var, folderinfo, cfg):
             multcomp_df, stats_var, anova_design, folderinfo, cfg
         )
         plot_multcomp_results(
-            g_avg_dfs, g_std_dfs, multcomp_df, stats_var, folderinfo, cfg
+            g_avg_dfs,
+            g_std_dfs,
+            multcomp_df,
+            stats_var,
+            folderinfo,
+            cfg,
+            plot_panel_instance,
         )
     else:  # if interaction effect not sig, inform user that we didn't perform Tukey's!
         nonsig_multcomp_df = pd.DataFrame()
@@ -1597,7 +1623,7 @@ def run_ANOVA(stats_df, stats_var, cfg):
 
 # ...................................  plot results  ...................................
 def plot_multcomp_results(
-    g_avg_dfs, g_std_dfs, multcomp_df, stats_var, folderinfo, cfg
+    g_avg_dfs, g_std_dfs, multcomp_df, stats_var, folderinfo, cfg, plot_panel_instance
 ):
     """Plot an Nx1 figure of N contrasts' multiple comparison results."""
 
@@ -1742,10 +1768,11 @@ def plot_multcomp_results(
         y=0.993,
     )
     save_figures(f, results_dir, figure_file_string)
-    if dont_show_plots:
-        plt.close(f)
-    else:
-        plt.show()
+
+    plt.close(f)
+    # add figure to plot panel figures list
+    if dont_show_plots is False:  # -> show plot panel
+        plot_panel_instance.figures.append(f)
 
 
 def extract_multcomp_significance_clusters(multcomp_df, contrast, stats_threshold):
@@ -1773,7 +1800,7 @@ def extract_multcomp_significance_clusters(multcomp_df, contrast, stats_threshol
 # %% ..........................  local functions #8 - plots  ...........................
 
 
-def plot_results(g_avg_dfs, g_std_dfs, folderinfo, cfg):
+def plot_results(g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance):
     """Plot results - main function (inner functions loop over groups)"""
 
     # unpack
@@ -1781,25 +1808,39 @@ def plot_results(g_avg_dfs, g_std_dfs, folderinfo, cfg):
     angles = cfg["angles"]
 
     # ........................1 - y coords over average SC..............................
-    plot_joint_y_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg)
+    plot_joint_y_by_average_SC(
+        g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+    )
 
     # ........................2 - angles over average SC................................
     if angles["name"]:
-        plot_angles_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg)
+        plot_angles_by_average_SC(
+            g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+        )
 
     # .................3 - average x velocities over SC percentage......................
-    plot_x_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg)
+    plot_x_velocities_by_average_SC(
+        g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+    )
 
     # ..............4 - average angular velocities over SC percentage...................
     if angles["name"]:
-        plot_angular_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg)
+        plot_angular_velocities_by_average_SC(
+            g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+        )
 
-    # plot stuff if wanted
-    if dont_show_plots is False:
-        plt.show()
+    # ........................optional - 5 - build plot panel..........................
+    if cfg["dont_show_plots"] is True:
+        pass  # going on without building the plot window
+    elif cfg["dont_show_plots"] is False:  # -> show plot panel
+        # Destroy loading screen and build plot panel with all figures
+        plot_panel_instance.destroy_plot_panel_loading_screen()
+        plot_panel_instance.build_plot_panel()
 
 
-def plot_joint_y_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
+def plot_joint_y_by_average_SC(
+    g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+):
     """1 - Plot joints' y as a function of average SC's percentage"""
 
     # unpack
@@ -1855,8 +1896,11 @@ def plot_joint_y_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
             ax.set_ylabel("Z")
             figure_file_string = " - Joint Z-coord.s over average step cycle"
         save_figures(f, results_dir, group_name + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
     # B - lines = groups & figures = joints
     for j, joint in enumerate(joints):
@@ -1901,11 +1945,16 @@ def plot_joint_y_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
             ax.set_ylabel("Z")
             figure_file_string = "- Z-coord.s over average step cycle"
         save_figures(f, results_dir, joint + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
 
-def plot_angles_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
+def plot_angles_by_average_SC(
+    g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+):
     """2 - Plot Angles as a function of average SC's percentage"""
 
     # unpack
@@ -1955,8 +2004,11 @@ def plot_angles_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
             )
         figure_file_string = " - Joint angles over average step cycle"
         save_figures(f, results_dir, group_name + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
     # B - lines = groups & figures = angles
     for a, angle in enumerate(angles["name"]):
@@ -1994,11 +2046,16 @@ def plot_angles_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
             ax.set_title(title_leg + " " + angle + " angle over average step cycle")
         figure_file_string = " - Angle over average step cycle"
         save_figures(f, results_dir, angle + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
 
-def plot_x_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
+def plot_x_velocities_by_average_SC(
+    g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+):
     """3 - Plot x velocities as a function of average SC's percentage"""
 
     # unpack
@@ -2069,8 +2126,11 @@ def plot_x_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
             )
         figure_file_string = " - Joint velocities over average step cycle"
         save_figures(f, results_dir, group_name + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
     # B - lines = groups & figures = joints
     for j, joint in enumerate(joints):
@@ -2127,11 +2187,16 @@ def plot_x_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
             )
         figure_file_string = "- Velocities over average step cycle"
         save_figures(f, results_dir, joint + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
 
-def plot_angular_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg):
+def plot_angular_velocities_by_average_SC(
+    g_avg_dfs, g_std_dfs, folderinfo, cfg, plot_panel_instance
+):
     """4 - Plot angular velocities as a function of average SC's percentage"""
     # unpack
     group_names = folderinfo["group_names"]
@@ -2186,8 +2251,11 @@ def plot_angular_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg)
             )
         figure_file_string = " - Angular velocities over average step cycle"
         save_figures(f, results_dir, group_name + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
     # B - lines = groups & figures = joints
     for a, angle in enumerate(angles["name"]):
@@ -2232,8 +2300,11 @@ def plot_angular_velocities_by_average_SC(g_avg_dfs, g_std_dfs, folderinfo, cfg)
             )
         figure_file_string = " - Angular Velocities over average step cycle"
         save_figures(f, results_dir, angle + figure_file_string)
-        if dont_show_plots:
-            plt.close(f)
+        plt.close(f)
+
+        # add figure to plot panel figures list
+        if dont_show_plots is False:  # -> show plot panel
+            plot_panel_instance.figures.append(f)
 
 
 def save_figures(figure, results_dir, figure_file_string):
@@ -2485,6 +2556,138 @@ def save_stats_results_to_text(results_df, stats_var, which_test, folderinfo, cf
     stats_textfile = os.path.join(results_dir, STATS_TXT_FILENAME)
     with open(stats_textfile, "a") as f:
         f.write(message)
+
+
+class PlotPanel:
+    def __init__(self):
+        self.figures = []
+        self.current_fig_index = 0
+
+    # .........................  loading screen  ................................
+    def build_plot_panel_loading_screen(self):
+        """Builds a loading screen that is shown while plots are generated"""
+        # Build window
+        self.loading_screen = ctk.CTkToplevel()
+        self.loading_screen.title("Loading...")
+        self.loading_screen.geometry("300x300")
+        self.loading_label_strings = [
+            "Plots are generated, please wait.",
+            "Plots are generated, please wait..",
+            "Plots are generated, please wait...",
+        ]
+        self.loading_label = ctk.CTkLabel(
+            self.loading_screen, text=self.loading_label_strings[0]
+        )
+        self.loading_label.pack(pady=130, padx=40, anchor="w")
+
+        # Animate the text
+        self.animate(counter=1)
+
+    # Cycle through loading labels to animate the loading screen
+    def animate(self, counter):
+        self.loading_label.configure(text=self.loading_label_strings[counter])
+        self.loading_screen.after(
+            500, self.animate, (counter + 1) % len(self.loading_label_strings)
+        )
+
+    def destroy_plot_panel_loading_screen(self):
+        self.loading_screen.destroy()
+
+    # .........................  plot panel   ................................
+    def build_plot_panel(self):
+        """Creates the window/"panel" in which the plots are shown"""
+        # Set up of the plotpanel
+        ctk.set_appearance_mode("dark")  # Modes: system (default), light, dark
+        ctk.set_default_color_theme("green")  # Themes: blue , dark-blue, green
+        self.plotwindow = ctk.CTkToplevel()
+        self.plotwindow.title(
+            f"AutoGaitA Plot Panel {self.current_fig_index+1}/{len(self.figures)}"
+        )
+
+        # Set size to 50% of screen
+        screen_width = self.plotwindow.winfo_screenwidth()
+        window_width = int(screen_width * 0.5)
+        # 0.75 to gain a ration of 1.333 (that of matplotlib figures) and 1.05 for toolbar + buttons
+        window_height = window_width * 0.75 * 1.05
+        self.plotwindow.geometry(f"{window_width}x{window_height}")
+
+        # Adjust figures for the plot panel
+        for fig in self.figures:
+            # dpi adjusted to increase visibilty/readability
+            fig.set_dpi(100)
+            # to adjust margins within the figure
+            # in case there are a lot of steps in one run (-> the legend is super long)
+            # the figure won't be displayed properly.
+            # fig.set_constrained_layout(True)
+
+        # Initialize the plot panel with the first figure
+        self.plot_panel = FigureCanvasTkAgg(
+            self.figures[self.current_fig_index], master=self.plotwindow
+        )  # index used for buttons
+        self.plot_panel.get_tk_widget().grid(
+            row=0, column=0, padx=10, pady=10, sticky="nsew"
+        )
+
+        # Create toolbar frame and place it in the middle row
+        self.toolbar_frame = tk.Frame(self.plotwindow)
+        self.toolbar_frame.grid(row=1, column=0, sticky="ew")
+
+        self.toolbar = NavigationToolbar2Tk(self.plot_panel, self.toolbar_frame)
+        self.toolbar.update()
+
+        # Create navigation buttons frame
+        self.button_frame = tk.Frame(self.plotwindow)
+        self.button_frame.grid(row=2, column=0, sticky="ew")
+
+        self.prev_button = ctk.CTkButton(
+            self.button_frame, text="<< Previous", command=self.show_previous
+        )
+        self.next_button = ctk.CTkButton(
+            self.button_frame, text="Next >>", command=self.show_next
+        )
+        self.prev_button.grid(row=0, column=0, sticky="ew")
+        self.next_button.grid(row=0, column=1, sticky="ew")
+
+        self.button_frame.grid_columnconfigure(0, weight=1)
+        self.button_frame.grid_columnconfigure(1, weight=1)
+
+        # Configure grid layout
+        self.plotwindow.grid_rowconfigure(0, weight=1)
+        self.plotwindow.grid_rowconfigure(1, weight=0)
+        self.plotwindow.grid_rowconfigure(2, weight=0)
+        self.plotwindow.grid_columnconfigure(0, weight=1)
+
+    def show_previous(self):
+        if self.current_fig_index > 0:
+            self.current_fig_index -= 1
+            self.update_plot_and_toolbar()
+
+    def show_next(self):
+        if self.current_fig_index < len(self.figures) - 1:
+            self.current_fig_index += 1
+            self.update_plot_and_toolbar()
+
+    def update_plot_and_toolbar(self):
+        # Clear the current plot panel
+        self.plot_panel.get_tk_widget().grid_forget()
+
+        # Update the plot panel with the new figure
+        self.plot_panel = FigureCanvasTkAgg(
+            self.figures[self.current_fig_index], master=self.plotwindow
+        )
+        self.plot_panel.get_tk_widget().grid(row=0, column=0, sticky="nsew")
+        self.plot_panel.draw()
+
+        # Destroy toolbar and create a new one
+        # (This has to be done, otherwise the toolbar won't function for a new plot)
+        self.toolbar.destroy()
+        self.toolbar = NavigationToolbar2Tk(self.plot_panel, self.toolbar_frame)
+        self.toolbar.update()
+
+        # Update title
+        self.plotwindow.title(
+            f"AutoGaitA Plot Panel {self.current_fig_index+1}/{len(self.figures)}"
+        )
 
 
 # %% what happens if we just hit run

--- a/autogaita/autogaita_group_gui.py
+++ b/autogaita/autogaita_group_gui.py
@@ -35,6 +35,7 @@ TK_BOOL_VARS = [
     "save_3D_PCA_video",
     "plot_SE",
     "legend_outside",
+    "dont_show_plots",
 ]
 TK_STR_VARS = [
     "anova_design",
@@ -504,6 +505,19 @@ def advanced_cfgwindow(mainwindow, root_dimensions):
     )
     save_PCA_video_checkbox.grid(row=10, column=0)
 
+      # dont show plots
+    dont_show_plots_string = "Don't show plots in GUI (save only)"
+    dont_show_plots_checkbox = ctk.CTkCheckBox(
+        cfgwindow,
+        text=dont_show_plots_string,
+        variable=cfg["dont_show_plots"],
+        onvalue=True,
+        offvalue=False,
+        fg_color=FG_COLOR,
+        hover_color=HOVER_COLOR,
+    )
+    dont_show_plots_checkbox.grid(row=11, column=0)
+
     # done button
     adv_cfg_done_button = ctk.CTkButton(
         cfgwindow,
@@ -512,7 +526,7 @@ def advanced_cfgwindow(mainwindow, root_dimensions):
         hover_color=HOVER_COLOR,
         command=lambda: cfgwindow.destroy(),
     )
-    adv_cfg_done_button.grid(row=11, column=0, sticky="nsew", pady=20, padx=80)
+    adv_cfg_done_button.grid(row=12, column=0, sticky="nsew", pady=20, padx=80)
 
     # maximise widgets to fit fullscreen
     maximise_widgets(cfgwindow)

--- a/autogaita/autogaita_simi_gui.py
+++ b/autogaita/autogaita_simi_gui.py
@@ -282,7 +282,7 @@ def simi_gui():
 
     # .............................  left section  .....................................
     # plot plots to python
-    showplots_string = "Don't show plots in Python (save only)"
+    showplots_string = "Don't show plots in GUI (save only)"
     showplots_checkbox = ctk.CTkCheckBox(
         root,
         text=showplots_string,

--- a/autogaita/batchrun_scripts/autogaita_group_dlcrun.py
+++ b/autogaita/batchrun_scripts/autogaita_group_dlcrun.py
@@ -29,6 +29,7 @@ def group_dlcrun():
     cfg["plot_SE"] = False
     cfg["color_palette"] = "viridis"
     cfg["legend_outside"] = True
+    cfg["dont_show_plots"] = False
     cfg["which_leg"] = "left"
     cfg["anova_design"] = "Mixed ANOVA"
     cfg["permutation_number"] = 100

--- a/autogaita/batchrun_scripts/autogaita_group_simirun.py
+++ b/autogaita/batchrun_scripts/autogaita_group_simirun.py
@@ -33,6 +33,7 @@ def group_simirun():
         cfg["plot_SE"] = False
         cfg["color_palette"] = "viridis"
         cfg["legend_outside"] = True
+        cfg["dont_show_plots"] = False
         cfg["anova_design"] = "Mixed ANOVA"
         cfg["PCA_variables"] = [
             "Midfoot, " + cfg["which_leg"] + " Z",


### PR DESCRIPTION
## Feature Description
In this initial draft PR I only added the plot panel to autogaita dlc. 

### The plot panel includes:
- all generated plots, 
- a toolbar to zoom, scroll, inspect and save the plot 
- buttons to move between each plot
![image](https://github.com/user-attachments/assets/d2d907e5-fdac-4a4f-9de1-55f55be54e31)

There is also small loading screen that inform the user that the plots are generate:
![image](https://github.com/user-attachments/assets/4d91d6d0-d16a-495f-b146-590ec8cc3505)

### Benefits
In the plot panel users can get a first overview of their analysed data and use the toolbar to inspect the graphs in more detail. They can get x and y coordinates of specific points, zoom in and out , adjust the x and y axes  and save these edited graphs/views as a separate file. 
![image](https://github.com/user-attachments/assets/412ed9b2-f75d-4efd-a3b3-bbe6f1c55e39)
 

## Code Description
To implement the plot panel I used matplotlibs tkinter backend (namely the  _FigureCanvasTkAgg_ function)
In order to neatly structure the code I build a class around the plot_panel that includes both the panel itself and the loading screen.

As the plots are displayed sightly different in the plot panel compared to when they are saved with_ save\_figure()_ (i.e. the proportions are weird and the legend is cut off) I changed the dpi and the right margin before showing them. I only change them after they have already been saved on the users computer.

## To Be Done
Check how the plot panel work/looks on a different pc/system and with another dataset to find potential bugs


